### PR TITLE
Adding support for blank value on resize/fitin and improving filter input

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,6 @@ Thumbor.prototype = {
    * @param  {String} halign 'left', 'center', 'right'
    */
   halign: function(halign) {
-    console.log('halign: ', halign);
     if (
       halign === this.LEFT ||
       halign === this.RIGHT ||


### PR DESCRIPTION
-On Thumbor Server you can set blank values to "Resize" and "Fitin" (100x or x100). So I decided to implement this option on your lib.

-When you need to use the same Thumbor instance (Secret + Server) to create other urls, it makes copies of the same filter in the Url (/fill(white):fill(white):fill(white)).

I decided to create a check on the filtersCalls push. In this way, we don't need to create another Thumbor instance to use the same filters with another image url.

-Removing console.log.
