### PR TITLE
Add support for image trimming

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function Thumbor(securityKey, thumborServerUrl) {
   this.valignValue = null;
   this.cropValues = null;
   this.meta = false;
+  this.trimValue = null;
   this.filtersCalls = [];
 }
 
@@ -33,6 +34,9 @@ Thumbor.prototype = {
   RIGHT: 'right',
   CENTER: 'center',
   LEFT: 'left',
+
+  TOP_LEFT: 'top-left',
+  BOTTOM_RIGHT: 'bottom-right',
 
   /**
    * Set path of image
@@ -73,6 +77,10 @@ Thumbor.prototype = {
 
     if (this.meta) {
       parts.push('meta');
+    }
+
+    if (this.trimValue) {
+      parts.push(this.trimValue);
     }
 
     if (this.cropValues) {
@@ -129,6 +137,34 @@ Thumbor.prototype = {
     }
 
     return parts;
+  },
+  /**
+   * Removes surrounding space in images using top-left pixel color unless specified otherwise.
+   * Overrides any previous call to `trim`.
+   * @param {String} orientation 'top-left', 'bottom-right'
+   * @param {Integer} tolerance between 0 and 442
+   */
+  trim: function(orientation, tolerance) {
+    var trimOpts = ['trim'];
+
+    if (orientation !== undefined) {
+      if (orientation === this.TOP_LEFT || orientation === this.BOTTOM_RIGHT) {
+        trimOpts.push(orientation);
+      } else {
+        throw new Error('Orientation must be top-left or bottom-right.');
+      }
+    }
+
+    if (tolerance !== undefined) {
+      if (tolerance > 0 && tolerance < 442) {
+        trimOpts.push(tolerance);
+      } else {
+        throw new Error('Tolerance must be between 0 and 442.');
+      }
+    }
+
+    this.trimValue = trimOpts.join(':');
+    return this;
   },
   /**
    * Resize the image to the specified dimensions. Overrides any previous call


### PR DESCRIPTION
This adds a way to explicitly apply trim options. Another way to apply trimming is to prepend `trim/` to the `imagePath`, but when combined with filters (since `trim/` is now considered a part of `imagePath`) the final generated URL puts the filters before the `trim` which is not the way Thumbor expects the parameters to be organized causing an error response.

Example of an incorrectly formatted URL: 
```node
var Thumbor = require('thumbor')

const t = new Thumbor('KEY', 'http://thumbor.com')

t.setImagePath('trim/http://imgserver.com/image.png').filter('colorize(100,100,100,ffffff)').buildUrl()
// http://thumbor.com/-WBeY7C5iB0GJqFsu1HESfCi7rs=/filters:colorize(100,100,100,ffffff)/trim/http://imgserver.com/image.png
```

Examples of URLs using `trim` options:

```node
var Thumbor = require('thumbor')

const t = new Thumbor('KEY', 'http://thumbor.com')

t.setImagePath('http://imgserver.com/image.png')

t.trim().buildUrl()
// http://thumbor.com/TaFyTswL4p1WRg9br4_rVv_hecY=/trim/http://imgserver.com/image.png

t.trim().filter('colorize(100,100,100,ffffff)').buildUrl()
// http://thumbor.com/9usuNQ8OniFoZ54aFf2j-Agmfl4=/trim/filters:colorize(100,100,100,ffffff)/http://imgserver.com/image.png

t.trim('bottom-right').buildUrl()
// http://thumbor.com/7EYHJRUQgH9LdB2e_BA-mzB5nsw=/trim:bottom-right/http://imgserver.com/image.png

t.trim('top-left', 30).buildUrl()
// http://thumbor.com/MMTAuxAU4E6TK79qVSHniOY9t_A=/trim:top-left:30/http://imgserver.com/image.png
```