### PR TITLE
Use crypto-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var crypto = require('crypto');
+var hmacSha1 = require('crypto-js/hmac-sha1');
+var base64 = require('crypto-js/enc-base64');
 
 /**
  * @param {[type]} securityKey
@@ -256,10 +257,9 @@ Thumbor.prototype = {
 
     if (this.THUMBOR_SECURITY_KEY) {
 
-      var key = crypto
-        .createHmac('sha1', this.THUMBOR_SECURITY_KEY)
-        .update(operation + this.imagePath)
-        .digest('base64');
+      var key = base64.stringify(
+        hmacSha1(operation + this.imagePath, this.THUMBOR_SECURITY_KEY)
+      )
 
       key = key.replace(/\+/g, '-').replace(/\//g, '_');
 

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "readme": "Client Thumbor for Node JS",
   "readmeFilename": "README.md",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "crypto-js": "^3.3.0"
+  }
 }


### PR DESCRIPTION
Using crypto-js could minimize build size. This could save about 200 KB of js file size when comparing to use NodeJS crypto library.

Before:
![image](https://user-images.githubusercontent.com/11766919/101875092-9daa3480-3bbc-11eb-808d-22136d758b47.png)

After:
![image](https://user-images.githubusercontent.com/11766919/101875360-0f827e00-3bbd-11eb-8d3e-fa1c218e85c3.png)
